### PR TITLE
Upgrading to latest roaring.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.2</version>
         </dependency>
  
         <!-- Tests -->


### PR DESCRIPTION
The toImmutableRoaringBitmap method is unnecessary and buggy. Version 0.4.2 removes it. Please upgrade to avoid potential problems.

Given a MutableRoaringBitmap, you can simply cast it to an ImmutableRoaringBitmap if you wish to have an ImmutableRoaringBitmap. In such a case, ImmutableRoaringBitmap will be effectively backed by a ByteBuffer held in RAM.
