### PR TITLE
Upgrading to roaring 0.4.5 (bug fix release)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
-            <version>0.4.3</version>
+            <version>0.4.5</version>
         </dependency>
  
         <!-- Tests -->


### PR DESCRIPTION
I recommend you update to roaring 0.4.5 as it fixes a rarely occurring bugs with some iterators (that would throw an exception).
