### PR TITLE
Upgrading to RoaringBitmap 0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
-            <version>0.4.5</version>
+            <version>[0.5.1,)</version>
         </dependency>
  
         <!-- Tests -->

--- a/src/main/java/com/metamx/collections/bitmap/RoaringBitmapFactory.java
+++ b/src/main/java/com/metamx/collections/bitmap/RoaringBitmapFactory.java
@@ -32,6 +32,8 @@ import java.util.Iterator;
  */
 public class RoaringBitmapFactory implements BitmapFactory
 {
+  static final boolean DEFAULT_COMPRESS_RUN_ON_SERIALIZATION = false;
+
   private static final ImmutableRoaringBitmap EMPTY_IMMUTABLE_BITMAP;
 
   static {
@@ -49,10 +51,22 @@ public class RoaringBitmapFactory implements BitmapFactory
     }
   }
 
+  private final boolean compressRunOnSerialization;
+
+  public RoaringBitmapFactory()
+  {
+    this(DEFAULT_COMPRESS_RUN_ON_SERIALIZATION);
+  }
+
+  public RoaringBitmapFactory(boolean compressRunOnSerialization)
+  {
+    this.compressRunOnSerialization = compressRunOnSerialization;
+  }
+
   @Override
   public MutableBitmap makeEmptyMutableBitmap()
   {
-    return new WrappedRoaringBitmap();
+    return new WrappedRoaringBitmap(compressRunOnSerialization);
   }
 
   @Override
@@ -94,7 +108,7 @@ public class RoaringBitmapFactory implements BitmapFactory
   @Override
   public ImmutableBitmap union(Iterable<ImmutableBitmap> b)
   {
-    return new WrappedImmutableRoaringBitmap(BufferFastAggregation.horizontal_or(unwrap(b).iterator()));
+    return new WrappedImmutableRoaringBitmap(ImmutableRoaringBitmap.or(unwrap(b).iterator()));
   }
 
   @Override


### PR DESCRIPTION

For Druid, there are cases where Roaring without run-length encoding would give poor compression ratios, specifically when indexing sorted tables (something already noted in the original research article at http://arxiv.org/pdf/1402.6407.pdf). 

This PR upgrades Roaring to version 0.5.0 which now includes some form of run-length encoding. The introduction of run compression in Roaring solves this compression issue. We provide the numbers below (the dimension_xxx data sets were provided by the Druid team for testing purposes).

In our test, the new Roaring continues to provide superior performance for several types of queries.


dimension_033  (average size of a compressed bitmap)

     Roaring with runOptimize :      421.2B 
     old-style Roaring:            23151.6B
     Consize:                        736.6B


dimension_008  (average size of a compressed bitmap)


     Roaring with runOptimize :      17.4B 
     old-style Roaring:             353.4B
     Concise:                        11.5B

dimension_003  (average size of a compressed bitmap)

     Roaring with runOptimize :        21.8B 
     old-style Roaring:               442.8B
     Concise:                          12.0B

census1881   (average size of a compressed bitmap)


     Roaring with runOptimize :        9459.8B 
     old-style Roaring:               10022.4B
     Concise:                         16031.4B
     
census1881_srt (average size of a compressed bitmap)

     Roaring with runOptimize :        920.2B 
     old-style Roaring:               2591.7B
     Concise:                         1049.7B


weather_sept_85 (average size of a compressed bitmap)


     Roaring with runOptimize :       43283.9B 
     old-style Roaring:               43755.6B
     Concise:                         47312.0B


weather_sept_85_srt (average size of a compressed bitmap)


     Roaring with runOptimize :        3423.9B 
     old-style Roaring:               32662.8B
     Concise:                          4370.0B


wikileaks-noquotes (average size of a compressed bitmap)

     Roaring with runOptimize :       1013.9B 
     old-style Roaring:               2837.2B
     Concise:                         1759.9B

wikileaks-noquotes_srt (average size of a compressed bitmap)

     Roaring with runOptimize :        293.6B 
     old-style Roaring:               1921.4B
     Concise:                          397.3B


census-income (average size of a compressed bitmap)

     Roaring with runOptimize :       11233.6B
     old-style Roaring:               11859.1B
     Concise:                         12698.7B

census-income_srt (average size of a compressed bitmap)

     Roaring with runOptimize :        2279.0B
     old-style Roaring:               11375.2B
     Concise:                          2087.6B