### PR TITLE
Fix Serde for Roaring bitmaps

### DIFF
--- a/src/main/java/com/metamx/collections/bitmap/RoaringBitmapFactory.java
+++ b/src/main/java/com/metamx/collections/bitmap/RoaringBitmapFactory.java
@@ -85,15 +85,7 @@ public class RoaringBitmapFactory implements BitmapFactory
       throw new IllegalStateException(String.format("Cannot convert [%s]", mutableBitmap.getClass()));
     }
     try {
-      final ByteArrayOutputStream out = new ByteArrayOutputStream();
-      ((WrappedRoaringBitmap) mutableBitmap).getBitmap().serialize(new DataOutputStream(out));
-      final byte[] bytes = out.toByteArray();
-
-
-      ByteBuffer buf = ByteBuffer.wrap(bytes);
-      return new WrappedImmutableRoaringBitmap(
-          new ImmutableRoaringBitmap(buf)
-      );
+      return ((WrappedRoaringBitmap) mutableBitmap).toImmutableBitmap();
     }
     catch (Exception e) {
       throw Throwables.propagate(e);

--- a/src/main/java/com/metamx/collections/bitmap/WrappedConciseBitmap.java
+++ b/src/main/java/com/metamx/collections/bitmap/WrappedConciseBitmap.java
@@ -125,9 +125,7 @@ public class WrappedConciseBitmap implements MutableBitmap
   @Override
   public void serialize(ByteBuffer buffer)
   {
-    byte[] bytes = ImmutableConciseSet.newImmutableFromMutable(bitmap).toBytes();
-    buffer.putInt(bytes.length);
-    buffer.put(bytes);
+    buffer.put(toBytes());
   }
 
   @Override

--- a/src/test/java/com/metamx/collections/bitmap/WrappedRoaringBitmapTest.java
+++ b/src/test/java/com/metamx/collections/bitmap/WrappedRoaringBitmapTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2011 - 2015 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.metamx.collections.bitmap;
+
+import com.metamx.collections.IntSetTestUtility;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Set;
+import junit.framework.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class WrappedRoaringBitmapTest
+{
+  @Parameterized.Parameters
+  public static List<RoaringBitmapFactory[]> factoryClasses()
+  {
+    return Arrays.asList(
+        (RoaringBitmapFactory[]) Arrays.asList(
+            new RoaringBitmapFactory(false)
+        ).toArray(),
+        (RoaringBitmapFactory[]) Arrays.asList(
+            new RoaringBitmapFactory(true)
+        ).toArray()
+    );
+  }
+
+  private final RoaringBitmapFactory factory;
+
+  public WrappedRoaringBitmapTest(RoaringBitmapFactory factory)
+  {
+    this.factory = factory;
+  }
+
+  private WrappedRoaringBitmap createWrappedRoaringBitmap()
+  {
+    WrappedRoaringBitmap set = (WrappedRoaringBitmap) factory.makeEmptyMutableBitmap();
+    set.add(1);
+    set.add(3);
+    set.add(5);
+    set.add(7);
+    set.add(9);
+    return set;
+  }
+
+  @Test
+  public void testSerialize()
+  {
+    WrappedRoaringBitmap set = createWrappedRoaringBitmap();
+
+    byte[] buffer = new byte[set.getSizeInBytes()];
+    ByteBuffer byteBuffer = ByteBuffer.wrap(buffer);
+    set.serialize(byteBuffer);
+    byteBuffer.flip();
+    ImmutableBitmap immutableBitmap = new RoaringBitmapFactory().mapImmutableBitmap(byteBuffer);
+    Assert.assertEquals(5, immutableBitmap.size());
+  }
+
+  @Test
+  public void testToByteArray()
+  {
+    WrappedRoaringBitmap set = createWrappedRoaringBitmap();
+    ImmutableBitmap immutableBitmap = new RoaringBitmapFactory().mapImmutableBitmap(ByteBuffer.wrap(set.toBytes()));
+    Assert.assertEquals(5, immutableBitmap.size());
+  }
+
+}


### PR DESCRIPTION
- Fix serde for roaring bitmaps. (Remove additional size being added in serialize method)
- fix compression. (fix toBytes method to use compression)
- remove getBitmap() from WrappedRoaringBitmap
- Add test for serde. 