### PR TITLE
Fix WrappedImmutableConciseBitmap.contains

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.metamx</groupId>
             <artifactId>extendedset</artifactId>
-            <version>1.3.9</version>
+            <version>1.3.10</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/java/com/metamx/collections/bitmap/WrappedImmutableConciseBitmap.java
+++ b/src/main/java/com/metamx/collections/bitmap/WrappedImmutableConciseBitmap.java
@@ -52,7 +52,7 @@ public class WrappedImmutableConciseBitmap implements ImmutableBitmap
   @Override
   public boolean get(int value)
   {
-    return bitmap.get(value) > 0;
+    return bitmap.contains(value);
   }
 
   @Override

--- a/src/test/java/com/metamx/collections/bitmap/ConciseBitmapFactoryTest.java
+++ b/src/test/java/com/metamx/collections/bitmap/ConciseBitmapFactoryTest.java
@@ -17,12 +17,16 @@
 package com.metamx.collections.bitmap;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import it.uniroma3.mat.extendedset.intset.ConciseSet;
+import it.uniroma3.mat.extendedset.intset.ImmutableConciseSet;
 import junit.framework.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Set;
 
 public class ConciseBitmapFactoryTest
 {
@@ -66,5 +70,22 @@ public class ConciseBitmapFactoryTest
     );
 
     Assert.assertEquals(3, bitmap.size());
+  }
+
+  @Test
+  public void testGetOutOfBounds()
+  {
+    final ConciseSet conciseSet = new ConciseSet();
+    final Set<Integer> ints = ImmutableSet.of(0, 4, 9);
+    for (int i : ints) {
+      conciseSet.add(i);
+    }
+    final ImmutableBitmap immutableBitmap = new WrappedImmutableConciseBitmap(
+        ImmutableConciseSet.newImmutableFromMutable(conciseSet));
+    final MutableBitmap mutableBitmap = new WrappedConciseBitmap(conciseSet);
+    for (int i = 0; i < 10; ++i) {
+      Assert.assertEquals(Integer.toString(i), ints.contains(i), mutableBitmap.get(i));
+      Assert.assertEquals(Integer.toString(i), ints.contains(i), immutableBitmap.get(i));
+    }
   }
 }


### PR DESCRIPTION
Fix #31 by using updates in the latest extendedset https://github.com/metamx/extendedset/pull/6